### PR TITLE
converted list to nparray in compute_descriptors

### DIFF
--- a/src/facenet_models/__init__.py
+++ b/src/facenet_models/__init__.py
@@ -71,10 +71,10 @@ class FacenetModel:
         np.ndarray, shape=(N, 512)
             The descriptor vectors, where N is the number of faces.
         """
-        crops = [
-            crop_resize(image, [int(max(0, coord)) for coord in box], 160)
-            for box in boxes
-        ]
+        crops = np.array(
+            [crop_resize(image, [int(max(0, coord)) for coord in box], 160)
+            for box in boxes], dtype='int32'
+            )
         crops = (torch.tensor(crops).float() - 127.5) / 128
         with torch.no_grad():
             return (


### PR DESCRIPTION
Fixed the following warning:
```
UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at  /Users/distiller/project/conda/conda-bld/pytorch_1646755922314/work/torch/csrc/utils/tensor_new.cpp:210.)
  crops = (torch.tensor(crops).float() - 127.5) / 128
```

Converting the list into an nparray yields a slight improvement to performance - in my testing, extracting the vectors in the whispers notebook went from 22.7s to 20.9s. I confirmed that the new code works as expected in both Whisper_Tutorial and FaceRecognitionTutorial notebooks.